### PR TITLE
Fix session redirect handling

### DIFF
--- a/Landing.html
+++ b/Landing.html
@@ -127,11 +127,15 @@
         const urlToken = getUrlParameter('token');
         let sessionToken = urlToken || sessionStorage.getItem('sessionToken');
 
+        if (urlToken) {
+            debugLog('Session token found in URL. Saving to sessionStorage.');
+            sessionStorage.setItem('sessionToken', urlToken);
+        } else if (sessionToken) {
+            debugLog('Session token loaded from sessionStorage.');
+        }
+
         if (sessionToken) {
-            if (urlToken) {
-                sessionStorage.setItem('sessionToken', urlToken);
-            }
-            debugLog(`Token is valid. Preparing to call server function getLandingPageData.`);
+            debugLog('Token is valid. Preparing to call server function getLandingPageData.');
             google.script.run
                 .withSuccessHandler(onDataReceived)
                 .withFailureHandler(handleFailure)


### PR DESCRIPTION
## Summary
- Automatically store session token and redirect from the interim redirect page
- Improve landing page token retrieval with debug logs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894b91a60f883319c296c658521bfa8